### PR TITLE
Use nerd-icons-icon-for-buffer

### DIFF
--- a/nerd-icons-ibuffer.el
+++ b/nerd-icons-ibuffer.el
@@ -136,16 +136,11 @@ See `ibuffer-formats' for details."
 (define-ibuffer-column icon
   (:name "" :inline t)
   (if nerd-icons-ibuffer-icon
-      (let ((icon (cond ((and (buffer-file-name) (nerd-icons-auto-mode-match?))
-                         (nerd-icons-icon-for-file (file-name-nondirectory (buffer-file-name))
-                                                   :height nerd-icons-ibuffer-icon-size))
-                        ((eq major-mode 'dired-mode)
-                         (nerd-icons-icon-for-dir (buffer-name)
-                                                  :height nerd-icons-ibuffer-icon-size
-                                                  :face 'nerd-icons-ibuffer-dir-face))
-                        (t
-                         (nerd-icons-icon-for-mode major-mode
-                                                   :height nerd-icons-ibuffer-icon-size)))))
+      (let ((icon (if (eq major-mode 'dired-mode)
+                      (nerd-icons-icon-for-dir (buffer-name)
+                                               :height nerd-icons-ibuffer-icon-size
+                                               :face 'nerd-icons-ibuffer-dir-face)
+                    (nerd-icons-icon-for-buffer :height nerd-icons-ibuffer-icon-size))))
         (concat
          (if (or (null icon) (symbolp icon))
              (nerd-icons-faicon "nf-fa-file_o"


### PR DESCRIPTION
`nerd-icons-icon-for-buffer` is equivalent to the current logic, but calling it means we can benefit from any upstream improvements.

Motivation: I'm submitting this because I plan on submitting an upstream (nerd-icons) patch to support X window icons for EXWM buffers where we can't rely on either the file-name or the major-mode.

**NOTE:** This depends on the recently merged https://github.com/rainstormstudio/nerd-icons.el/pull/124